### PR TITLE
Fix line endings rendering outside selection

### DIFF
--- a/out/extension.js
+++ b/out/extension.js
@@ -134,7 +134,7 @@ function activate(context) {
                         if ((selections !== null) && selections.length > 0) {
                             selections.forEach(selection => { //check each selection
                                 const hasSelection = (selection.start.line !== selection.end.line) || (selection.start.character !== selection.end.character)
-                                if (hasSelection && eolPosition.isAfterOrEqual(selection.start) && eolPosition.isBeforeOrEqual(selection.end)) {
+                                if (hasSelection && eolPosition.isAfterOrEqual(selection.start) && eolPosition.isBefore(selection.end)) {
                                     shouldDecorate = true
                                     return
                                 }


### PR DESCRIPTION
**Disclaimer:** I am not familiar with the process of developing extensions for Visual Studio Code.

---

Currently, when `editor.renderWhitespace` is set to `selection`, it is possible for line endings to render outside of the selected text. This behavior is not ideal. An example of this behavior is shown in the image below.
<img src="https://user-images.githubusercontent.com/69266322/130371146-82aa6ef1-757c-44ee-afc7-9cf353e0609a.png" width="480"></img>

Instead, when `editor.renderWhitespace` is set to `selection`, line endings should only render when they are selected. An example of this behavior is shown in the image below.
<img src="https://user-images.githubusercontent.com/69266322/130371148-9eeb9028-6058-493e-8831-ee91d307ce1c.png" width="480"></img>

The selection end position is not inclusive of the currently selected text. In addition to this, the end of line position is compared to the selection end position using `isBeforeOrEqual` when determining whether to render the end of line character or not. Because of these two things, the end of line character can be rendered when the selection ends right before the the end of line character. To fix this issue, the `isBefore` function should be used to compare the end of line and selection end positions instead of `isBeforeOrEqual`.

This pull request implements the small fix described above.