### PR TITLE
Add text decoration instead of changing text color for extra whitespace

### DIFF
--- a/out/extension.js
+++ b/out/extension.js
@@ -105,7 +105,7 @@ function activate(context) {
                 extraWhitespaceDecorationType.dispose()
                 if (isDebug) { console.debug(new Date().getTime() + '   renderDecorations() disposed old extra whitespace decorations') }
             }
-            extraWhitespaceDecorationType = vscode.window.createTextEditorDecorationType({ backgroundColor: themeColorError })
+            extraWhitespaceDecorationType = vscode.window.createTextEditorDecorationType({ textDecoration: 'line-through dotted var(--vscode-editorError-foreground)' })
             if (isDebug) { console.debug(new Date().getTime() + '   renderDecorations() created new extra whitespace decorations (' + id + ')') }
             extraWhitespaceDecorationTypes[id] =  extraWhitespaceDecorationType
         }

--- a/out/extension.js
+++ b/out/extension.js
@@ -105,7 +105,7 @@ function activate(context) {
                 extraWhitespaceDecorationType.dispose()
                 if (isDebug) { console.debug(new Date().getTime() + '   renderDecorations() disposed old extra whitespace decorations') }
             }
-            extraWhitespaceDecorationType = vscode.window.createTextEditorDecorationType({ color: themeColorError })
+            extraWhitespaceDecorationType = vscode.window.createTextEditorDecorationType({ backgroundColor: themeColorError })
             if (isDebug) { console.debug(new Date().getTime() + '   renderDecorations() created new extra whitespace decorations (' + id + ')') }
             extraWhitespaceDecorationTypes[id] =  extraWhitespaceDecorationType
         }

--- a/out/extension.js
+++ b/out/extension.js
@@ -114,6 +114,7 @@ function activate(context) {
                 experimentalWhitespaceRendering === 'off'
                     ? { color: themeColorError }
                     : { textDecoration: 'line-through dotted var(--vscode-editorError-foreground)' }
+            extraWhitespaceDecorationOptions.rangeBehavior = vscode.DecorationRangeBehavior.ClosedClosed
             extraWhitespaceDecorationType = vscode.window.createTextEditorDecorationType(extraWhitespaceDecorationOptions)
             if (isDebug) { console.debug(new Date().getTime() + '   renderDecorations() created new extra whitespace decorations (' + id + ')') }
             lastExperimentalWhitespaceRendering = experimentalWhitespaceRendering

--- a/out/extension.js
+++ b/out/extension.js
@@ -22,10 +22,12 @@ function activate(context) {
     // to determine if decoration types need recreation
     var lastEolSymbol = null
     var lastDecorationBeforeEof = null
+    var lastExperimentalWhitespaceRendering = null
 
     // settings
     var defaultRenderWhitespace
     var defaultWordWrap
+    var defaultExperimentalWhitespaceRendering
     var defaultEol
     var defaultSymbolLF
     var defaultSymbolCR
@@ -53,6 +55,7 @@ function activate(context) {
 
         const [
             renderWhitespace,
+            experimentalWhitespaceRendering,
             wordWrap,
             eol,
             symbolLF,
@@ -99,14 +102,21 @@ function activate(context) {
         }
 
         let extraWhitespaceDecorationType = (id in extraWhitespaceDecorationTypes) ? extraWhitespaceDecorationTypes[id] : null
-        if ((extraWhitespaceDecorationType == null) || configurationUpdate) {
+        if ((extraWhitespaceDecorationType == null) || configurationUpdate || (lastExperimentalWhitespaceRendering !== experimentalWhitespaceRendering)) {
             if (extraWhitespaceDecorationType != null) {
                 if (editor.setDecorations) { editor.setDecorations(extraWhitespaceDecorationType, []) }
                 extraWhitespaceDecorationType.dispose()
                 if (isDebug) { console.debug(new Date().getTime() + '   renderDecorations() disposed old extra whitespace decorations') }
             }
-            extraWhitespaceDecorationType = vscode.window.createTextEditorDecorationType({ textDecoration: 'line-through dotted var(--vscode-editorError-foreground)' })
+            // Without experimental whitespace rendering, middle dots inserted into the text can be colored
+            // Otherwise, the whitespace is rendered as an overlay, so the whitespace text cannot be colored
+            const extraWhitespaceDecorationOptions =
+                experimentalWhitespaceRendering === 'off'
+                    ? { color: themeColorError }
+                    : { textDecoration: 'line-through dotted var(--vscode-editorError-foreground)' }
+            extraWhitespaceDecorationType = vscode.window.createTextEditorDecorationType(extraWhitespaceDecorationOptions)
             if (isDebug) { console.debug(new Date().getTime() + '   renderDecorations() created new extra whitespace decorations (' + id + ')') }
+            lastExperimentalWhitespaceRendering = experimentalWhitespaceRendering
             extraWhitespaceDecorationTypes[id] =  extraWhitespaceDecorationType
         }
 
@@ -188,6 +198,7 @@ function activate(context) {
         const editorConfiguration = vscode.workspace.getConfiguration('editor', null)
         const newDefaultRenderWhitespace = editorConfiguration.get('renderWhitespace', 'none') || 'selection'
         const newDefaultWordWrap = editorConfiguration.get('wordWrap', 'off') || 'off'
+        const newDefaultExperimentalWhitespaceRendering = editorConfiguration.get('experimentalWhitespaceRendering', 'svg') || 'svg'
 
         const filesConfiguration = vscode.workspace.getConfiguration('files', null)
         const newDefaultEol = filesConfiguration.get('eol', 'auto') || 'auto'
@@ -203,6 +214,11 @@ function activate(context) {
 
         if (defaultRenderWhitespace !== newDefaultRenderWhitespace) {
             defaultRenderWhitespace = newDefaultRenderWhitespace
+            anyChanges = true
+        }
+
+        if (defaultExperimentalWhitespaceRendering !== newDefaultExperimentalWhitespaceRendering) {
+            defaultExperimentalWhitespaceRendering = newDefaultExperimentalWhitespaceRendering
             anyChanges = true
         }
 
@@ -256,6 +272,7 @@ function activate(context) {
     /** @param {vscode.TextDocument} document */
     function getDocumentSettings(document) {
         let renderWhitespace = defaultRenderWhitespace
+        let experimentalWhitespaceRendering = defaultExperimentalWhitespaceRendering
         let wordWrap = defaultWordWrap
         let eol = defaultEol
         let symbolLF = defaultSymbolLF
@@ -273,6 +290,9 @@ function activate(context) {
 
                 const languageSpecificRenderWhitespace = languageSpecificConfiguration['editor.renderWhitespace']
                 if (languageSpecificRenderWhitespace) { renderWhitespace = languageSpecificRenderWhitespace }
+
+                const languageSpecificExperimentalWhitespaceRendering = languageSpecificConfiguration['editor.experimentalWhitespaceRendering']
+                if (languageSpecificExperimentalWhitespaceRendering) { experimentalWhitespaceRendering = languageSpecificExperimentalWhitespaceRendering }
 
                 const languageSpecificWordWrap = languageSpecificConfiguration['editor.wordWrap']
                 if (languageSpecificWordWrap) { wordWrap = languageSpecificWordWrap }
@@ -307,6 +327,7 @@ function activate(context) {
 
         return [
             renderWhitespace,
+            experimentalWhitespaceRendering,
             wordWrap,
             eol,
             symbolLF,


### PR DESCRIPTION
## Premise
As described in #27, changing the text color of extra whitespace is no longer effective since whitespace dots are rendered as an overlay, not part of the text. As of now, I don't see a way to modify portions of the overlay style, so to maintain the extra whitespace indicator, a different decoration style is needed.

I originally proposed changing the background color, but upon use, it was too distracting while writing out a line. Some viable alternatives I considered were changing the border, outline, or text-decoration, and I eventually settled on using text-decoration. Another possibility would be indicating a code problem as some linters may do, but I think that is beyond the scope of this extension.

The new behavior will apply only when the experimental whitespace rendering is used. Otherwise, the original color approach will still be used.

## Changes
Check the `editor.experimentalWhitespaceRendering` preference to decide which style to use
- When set to `off`, keep the original color decoration
- Otherwise, add a text-decoration with a dotted strikethrough since raw whitespace cannot be colored