### PR TITLE
Add missing backtick

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ whitespace rendering is on.
 This extension contributes the following settings (compatible with `code-eol`
 extension):
 
-| Setting                               | Default | Description                                                                                                                                                                                    |
-| ------------------------------------- | :-----: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `"code-eol.newlineCharacter"`         |  `"↓"`  | Character used to display `LF`, Linux and Mac's line ending.                                                                                                                                   |
-| `"code-eol.returnCharacter"`          |  `"←"`  | Character used to display `CR`, old Macintosh' line ending.<br>Note: `CR` files are not supported by VS Code: see [`microsoft/vscode#35797](https://github.com/microsoft/vscode/issues/35797). |
-| `"code-eol.crlfCharacter"`            |  `"↵"`  | Character used to display `CRLF`, Windows' line ending.                                                                                                                                        |
-| `"code-eol.highlightNonDefault"`      | `false` | If set, non-standard line endings will be highlighted as errors.<br>The standard EOL is taken from `files.eol`.                                                                                |
-| `"code-eol.highlightExtraWhitespace"` | `false` | If set, trailing whitespace will be highlighted as errors.                                                                                                                                     |
-| `"code-eol.decorateBeforeEol"`        | `false` | If set, rendered characters will come before the end of the line.<br>Note: If set, line endings will not be rendered on empty lines.                                                           |
-| `"code-eol.forceShowOnWordWrap"`      | `false` | If set, rendered characters will always be shown when word wrap is on, regardless of the other settings.                                                                                       |
+| Setting                               | Default | Description                                                                                                                                                                                     |
+| ------------------------------------- | :-----: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"code-eol.newlineCharacter"`         |  `"↓"`  | Character used to display `LF`, Linux and Mac's line ending.                                                                                                                                    |
+| `"code-eol.returnCharacter"`          |  `"←"`  | Character used to display `CR`, old Macintosh' line ending.<br>Note: `CR` files are not supported by VS Code: see [`microsoft/vscode#35797`](https://github.com/microsoft/vscode/issues/35797). |
+| `"code-eol.crlfCharacter"`            |  `"↵"`  | Character used to display `CRLF`, Windows' line ending.                                                                                                                                         |
+| `"code-eol.highlightNonDefault"`      | `false` | If set, non-standard line endings will be highlighted as errors.<br>The standard EOL is taken from `files.eol`.                                                                                 |
+| `"code-eol.highlightExtraWhitespace"` | `false` | If set, trailing whitespace will be highlighted as errors.                                                                                                                                      |
+| `"code-eol.decorateBeforeEol"`        | `false` | If set, rendered characters will come before the end of the line.<br>Note: If set, line endings will not be rendered on empty lines.                                                            |
+| `"code-eol.forceShowOnWordWrap"`      | `false` | If set, rendered characters will always be shown when word wrap is on, regardless of the other settings.                                                                                        |
 
 ## Upstream Issues
 


### PR DESCRIPTION
(Should have been a 1-line diff, but the table had to be formatted)