### PR TITLE
Fix selection rendering when forceShowOnWordWrap is false

### DIFF
--- a/out/extension.js
+++ b/out/extension.js
@@ -66,7 +66,7 @@ function activate(context) {
             forceShowOnWordWrap
         ] = getDocumentSettings(editor.document)
         const shouldRenderEOL = ((renderWhitespace !== 'none') && (renderWhitespace !== 'boundary')) || (forceShowOnWordWrap && (wordWrap !== 'off'))
-        const shouldRenderOnlySelection = (renderWhitespace === 'selection') && (forceShowOnWordWrap && (wordWrap !== 'off'))
+        const shouldRenderOnlySelection = (renderWhitespace === 'selection') && !(forceShowOnWordWrap && (wordWrap !== 'off'))
 
         const lineEnding = document.eol
 


### PR DESCRIPTION
On version 1.8.4, the extension does not seem to respect the `"editor.renderWhitespace": "selection"` setting, rendering the line endings in the entire file instead.
The setting works correctly on version 1.8.3.
It seems to me that this is caused by changes in 51e74ff from issue #41.
The fix there seems to be missing a negation, making the behavior the opposite of what is expected.
That is, currently with the settings
```
"editor.renderWhitespace": "selection",
"code-eol.forceShowOnWordWrap": false,
"editor.wordWrap": "on",
```
the line endings are shown in the entire file, while with
```
"editor.renderWhitespace": "selection",
"code-eol.forceShowOnWordWrap": true,
"editor.wordWrap": "on",
```
only the selected part of the file shows the line endings.

The following PR adds that missing negation.